### PR TITLE
Use a generic Comparator paramater for most Block and Table APIs

### DIFF
--- a/src/compaction.rs
+++ b/src/compaction.rs
@@ -158,6 +158,7 @@ impl<O: File> Compaction<O> {
                     for file in self.inputs[CompactionInputsRelation::Source as usize].iter() {
                         // all the level0 tables are guaranteed being added into the table_cache via minor compaction
                         iter_list.push(Box::new(table_cache.new_iter(
+                            icmp.clone(),
                             read_options.clone(),
                             file.number,
                             file.file_size,
@@ -165,7 +166,8 @@ impl<O: File> Compaction<O> {
                     }
                 } else {
                     let origin = LevelFileNumIterator::new(icmp.clone(), self.inputs[i].clone());
-                    let factory = FileIterFactory::new(read_options, table_cache.clone());
+                    let factory =
+                        FileIterFactory::new(icmp.clone(), read_options, table_cache.clone());
                     iter_list.push(Box::new(ConcatenateIterator::new(origin, factory)));
                 }
             }

--- a/src/db/format.rs
+++ b/src/db/format.rs
@@ -267,8 +267,10 @@ impl LookupKey {
 ///    decreasing sequence number
 ///    decreasing type (though sequence# should be enough to disambiguate)
 #[derive(Clone)]
+// TODO: Make this impl Copy
 pub struct InternalKeyComparator {
     /// The comparator defined in `Options`
+    // TODO: Remove this Arc
     pub user_comparator: Arc<dyn Comparator>,
 }
 

--- a/src/version/mod.rs
+++ b/src/version/mod.rs
@@ -159,7 +159,13 @@ impl Version {
             for file in files_to_seek.iter() {
                 seek_stats.seek_file_level = Some(level);
                 seek_stats.seek_file = Some(file.clone());
-                match table_cache.get(options, &ikey, file.number, file.file_size)? {
+                match table_cache.get(
+                    self.icmp.clone(),
+                    options,
+                    &ikey,
+                    file.number,
+                    file.file_size,
+                )? {
                     None => continue, // keep searching
                     Some((encoded_key, value)) => {
                         match ParsedInternalKey::decode_from(encoded_key.as_slice()) {


### PR DESCRIPTION
Use a generic `Comparator` for most APIs in `Block` and `Table`.
This makes that the `Block` and `Table` can be operated by different `Comparator` instead of `options.comparator`. 

Signed-off-by: Fullstop000 <fullstop1005@gmail.com>