### PR TITLE
Add generic Comparator in TableBuilder and BlockBuilder

### DIFF
--- a/src/compaction.rs
+++ b/src/compaction.rs
@@ -84,7 +84,7 @@ pub struct Compaction<F: File> {
     // current table builder for output sst file
     // we rotate a new builder when the inputs hit
     // the `should_stop_before`
-    pub builder: Option<TableBuilder<F>>,
+    pub builder: Option<TableBuilder<InternalKeyComparator, F>>,
 
     // total bytes has been written
     pub total_bytes: u64,

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -1179,7 +1179,7 @@ pub(crate) fn build_table<S: Storage + Clone>(
     if iter.valid() {
         let file = storage.create(file_name.as_str())?;
         let icmp = InternalKeyComparator::new(options.comparator.clone());
-        let mut builder = TableBuilder::new(file, options);
+        let mut builder = TableBuilder::new(file, icmp.clone(), options);
         let mut prev_key = Slice::default();
         let smallest_key = iter.key();
         while iter.valid() {

--- a/src/version/version_set.rs
+++ b/src/version/version_set.rs
@@ -612,7 +612,11 @@ impl<S: Storage + Clone + 'static> VersionSet<S> {
         output.number = file_number;
         let file_name = generate_filename(self.db_name, FileType::Table, file_number);
         let file = self.storage.create(file_name.as_str())?;
-        compact.builder = Some(TableBuilder::new(file, self.options.clone()));
+        compact.builder = Some(TableBuilder::new(
+            file,
+            self.icmp.clone(),
+            self.options.clone(),
+        ));
         Ok(())
     }
 


### PR DESCRIPTION
Use generic `Comparator` in `TableBuilder` and `BlockBuilder` instead of `options.comparator`.
All the comparators must be the same in `TableBuilder`, `BlockBuilder`, `Table` and `BlockIterator`. 

Signed-off-by: Fullstop000 <fullstop1005@gmail.com>