### PR TITLE
skl: refactor skiplist

### DIFF
--- a/benches/mem/skiplist.rs
+++ b/benches/mem/skiplist.rs
@@ -18,7 +18,7 @@ fn bench_insert(c: &mut Criterion) {
                             vec![0u8; *length],
                         )
                     },
-                    |(s, key)| s.insert(key),
+                    |(s, key)| s.insert(&key),
                     BatchSize::PerIteration,
                 )
             },

--- a/src/mem/mod.rs
+++ b/src/mem/mod.rs
@@ -137,7 +137,7 @@ impl MemoryTable for MemTable {
         buf.extend_from_slice(key);
         put_fixed_64(&mut buf, (seq_number << 8) | val_type as u64);
         VarintU32::put_varint_prefixed_slice(&mut buf, value);
-        self.table.insert(buf);
+        self.table.insert(&buf);
     }
 
     fn get(&self, key: &LookupKey) -> Option<Result<Slice>> {

--- a/src/util/slice.rs
+++ b/src/util/slice.rs
@@ -142,6 +142,16 @@ impl Hash for Slice {
     }
 }
 
+impl AsRef<[u8]> for Slice {
+    fn as_ref(&self) -> &[u8] {
+        if !self.data.is_null() {
+            unsafe { slice::from_raw_parts(self.data, self.size) }
+        } else {
+            panic!("try to convert a empty(invalid) Slice as a &[u8] ")
+        }
+    }
+}
+
 impl<'a> From<&'a [u8]> for Slice {
     #[inline]
     fn from(v: &'a [u8]) -> Self {


### PR DESCRIPTION
Use a new `Node` struct which reduces the memory usage by a pointer size and simplify the implementation

```rust
struct Node {
    key: Slice,
    height: usize,
    next_nodes: [AtomicPtr<Node>; 0],
}
```

Signed-off-by: Fullstop000 <fullstop1005@gmail.com>