### PR TITLE
Use a new implementation for MergeIterator

### DIFF
--- a/src/db/format.rs
+++ b/src/db/format.rs
@@ -132,6 +132,7 @@ impl<'a> Debug for ParsedInternalKey<'a> {
 ///              user key                  seq number        type
 /// ```
 ///
+// TODO: use &'a [u8] instead of Vec<u8>
 #[derive(Clone, PartialEq, Eq)]
 pub struct InternalKey {
     data: Vec<u8>,

--- a/src/mem/skiplist.rs
+++ b/src/mem/skiplist.rs
@@ -342,7 +342,7 @@ impl<C: Comparator, A: Arena> SkiplistIterator<C, A> {
     }
 }
 
-/// Generate a random height < MAX_HEIGHT for node
+// Generate a random height < MAX_HEIGHT for node
 fn rand_height() -> usize {
     let mut height = 1;
     loop {

--- a/src/sstable/mod.rs
+++ b/src/sstable/mod.rs
@@ -374,9 +374,8 @@ mod tests {
     use crate::db::format::{
         InternalKeyComparator, LookupKey, ParsedInternalKey, ValueType, MAX_KEY_SEQUENCE,
     };
-    use crate::db::iterator::DBIterator;
-    use crate::db::{WickDB, DB};
-    use crate::iterator::{Iterator, MergingIterator};
+    use crate::db::{WickDB, WickDBIterator, DB};
+    use crate::iterator::Iterator;
     use crate::mem::{MemTable, MemTableIterator};
     use crate::options::{Options, ReadOptions};
     use crate::sstable::block::*;
@@ -761,7 +760,7 @@ mod tests {
     }
 
     impl Constructor for DBConstructor {
-        type Iter = DBIterator<MergingIterator<InternalKeyComparator>, MemStorage>;
+        type Iter = WickDBIterator<MemStorage>;
 
         fn new(is_reversed: bool) -> Self {
             let mut options = Options::default();

--- a/src/version/version_edit.rs
+++ b/src/version/version_edit.rs
@@ -414,7 +414,7 @@ impl Debug for VersionEdit {
 }
 
 fn get_internal_key(mut src: &mut &[u8]) -> Option<InternalKey> {
-    VarintU32::get_varint_prefixed_slice(&mut src).and_then(|s| Some(InternalKey::decoded_from(s)))
+    VarintU32::get_varint_prefixed_slice(&mut src).map(|s| InternalKey::decoded_from(s))
 }
 
 fn get_level(max_levels: u8, src: &mut &[u8]) -> Option<u32> {


### PR DESCRIPTION
The old implementation using `Vec<Box<dyn Iterator>>` as merging children, which makes every inner child boxed. 

To improve this, the PR
- Introduces `KMergeIter` and trait `KMergeCore` to unify the merging iterator logic. 
- Introduces an `SSTableIters` to yield all the entries in all SSTable files.

Signed-off-by: Fullstop000 <fullstop1005@gmail.com>