### PR TITLE
[DNM] test: UB in test_recover_during_memtable_compaction

### DIFF
--- a/src/version/mod.rs
+++ b/src/version/mod.rs
@@ -185,7 +185,13 @@ impl Version {
                                     == CmpOrdering::Equal
                                 {
                                     match parsed_key.value_type {
-                                        ValueType::Value => return Ok((Some(value), seek_stats)),
+                                        ValueType::Value => {
+                                            if value.size() > 30 {
+                                                info!("v1 {:?}", &value.as_slice()[..30]);
+                                                info!("{:?}: {}", value.as_ptr(), value.size());
+                                            }
+                                            return Ok((Some(value), seek_stats))
+                                        },
                                         ValueType::Deletion => return Ok((None, seek_stats)),
                                         _ => {}
                                     }


### PR DESCRIPTION
This PR shows that a UB occurs in `test_recover_during_memtable_compaction` when the value of key `big1` is very large.

```
May 01 23:14:14.453 INFO Reusing old log file db_test/000004.log, [location]: src/db/mod.rs:693
May 01 23:14:14.453 INFO Delete type=Log #3 [filename "/db_test/000003.log"], [location]: src/db/mod.rs:738
May 01 23:14:14.454 INFO Delete type=Table #5 [filename "/db_test/000005.sst"], [location]: src/db/mod.rs:738
May 01 23:14:14.951 INFO v1 [120, 120, 120, 120, 120, 120, 120, 120, 120, 120, 120, 120, 120, 120, 120, 120, 120, 120, 120, 120, 120, 120, 120, 120, 120, 120, 120, 120, 120, 120], [location]: src/version/mod.rs:190
May 01 23:14:14.952 INFO 0x7f16f09b38a2: 10000000, [location]: src/version/mod.rs:191
May 01 23:14:14.952 INFO v2: [156, 243, 22, 127, 0, 0, 48, 145, 170, 241, 22, 127, 0, 0, 120, 120, 120, 120, 120, 120, 120, 120, 120, 120, 120, 120, 120, 120, 120, 120], [location]: src/db/mod.rs:493
May 01 23:14:14.952 INFO 0x7f16f09b38a2: 10000000, [location]: src/db/mod.rs:494
thread 'db::tests::test_recover_during_memtable_compaction' panicked at 'expect(len=10000000), but got(len=10000000), not equal contents, key: big1, got: [156, 243, 22, 127, 0, 0, 48, 145, 170, 241, 22, 127, 0, 0, 120, 120, 120, 120, 120, 120, 120, 120, 120, 120, 120, 120, 120, 120, 120, 120, 120, 120, 120, 120, 120, 120, 120, 120, 120, 120, 120, 120, 120, 1
20, 120, 120, 120, 120, 120, 120]..., expect: [120, 120, 120, 120, 120, 120, 120, 120, 120, 120, 120, 120, 120, 120, 120, 120, 120, 120, 120, 120, 120, 120, 120, 120, 120, 120, 120, 120, 120, 120, 120, 120, 120, 120, 120, 120, 120, 120, 120, 120, 120, 120, 120, 120, 120, 120, 120, 120, 120, 120]...', src/db/mod.rs:1604:33
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
test db::tests::test_recover_during_memtable_compaction ... FAILED
```
There is only a `return` between this two logs output and they are same sometimes.
![image](https://user-images.githubusercontent.com/12471960/80816502-3548ad00-8c02-11ea-94c5-b4c1664e6376.png)

The location of these two logs:
https://github.com/Fullstop000/wickdb/pull/64/files#diff-915568373099f1e6db780d2288671d39R493
https://github.com/Fullstop000/wickdb/pull/64/files#diff-fee100b522153cf12f945357ba19ea17R189

And on the end of log itself, there is a `[location]` hints its exact code location.

The reason that it's strange is that: the two logs are produced in order and there are no other operations (just a return) between them.

Reproduce steps:
```shell
git clone https://github.com/Fullstop000/wickdb && cd wickdb
git checkout -b ub_test
cargo test test_recover_during_memtable_compaction  -- --nocapture
```
