### PR TITLE
*: remove some unsafe Slice usage

### DIFF
--- a/examples/simple_read_write.rs
+++ b/examples/simple_read_write.rs
@@ -42,6 +42,6 @@ fn main() {
         .expect("could not get key2");
     assert!(val1.is_some());
     assert!(val2.is_some());
-    assert_eq!(val1.unwrap().as_str(), "value1");
-    assert_eq!(val2.unwrap().as_str(), "value2");
+    assert_eq!(String::from_utf8(val1.unwrap()).unwrap(), "value1");
+    assert_eq!(String::from_utf8(val2.unwrap()).unwrap(), "value2");
 }

--- a/src/iterator.rs
+++ b/src/iterator.rs
@@ -22,7 +22,7 @@ use std::cmp::Ordering;
 
 /// A common trait for iterating all the key/value entries.
 ///
-/// An `Iterator` should be invalid once created
+/// An `Iterator` must be invalid once created
 pub trait Iterator {
     type Key;
     type Value;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -61,5 +61,4 @@ pub use options::{CompressionType, Options, ReadOptions, WriteOptions};
 pub use sstable::block::Block;
 pub use storage::*;
 pub use util::comparator::{BytewiseComparator, Comparator};
-pub use util::slice::Slice;
 pub use util::varint::*;

--- a/src/sstable/block.rs
+++ b/src/sstable/block.rs
@@ -115,17 +115,15 @@ pub struct BlockIterator<C: Comparator> {
     current: u32,
 
     /*
-     entry
+     Fields for entries in the Block
     */
     shared: u32,     // shared length
     not_shared: u32, // not shared length
     value_len: u32,  // value length
     key_offset: u32, // the offset of the key in the block
-    // TODO: remmove this buffer
-    //     Removing this buffer might be difficult becasue the key
-    //     could be formed by multiple segments which means we should
-    //     maintain predictable amount of offsets for each key.
-    key: Vec<u8>, // buffer for a completed key
+    // Buffer for a completed key
+    // The key is saperated in multiple segments in `data`.
+    key: Vec<u8>,
 }
 
 impl<C: Comparator> BlockIterator<C> {

--- a/src/sstable/table.rs
+++ b/src/sstable/table.rs
@@ -694,7 +694,7 @@ mod tests {
         iter.seek_to_first();
         let mut result_pairs = vec![];
         while iter.valid() {
-            result_pairs.push((iter.key().copy(), iter.value().copy()));
+            result_pairs.push((iter.key().into_vec(), iter.value().into_vec()));
             iter.next();
         }
         assert_eq!(result_pairs.len(), test_pairs.len());

--- a/src/util/slice.rs
+++ b/src/util/slice.rs
@@ -47,8 +47,9 @@ impl Slice {
         }
     }
 
+    // Returns a `Vec<u8>` copyed from inner
     #[inline]
-    pub fn copy(&self) -> Vec<u8> {
+    pub fn into_vec(&self) -> Vec<u8> {
         Vec::from(self.as_slice())
     }
 

--- a/src/version/mod.rs
+++ b/src/version/mod.rs
@@ -121,7 +121,7 @@ impl Version {
         options: ReadOptions,
         key: LookupKey,
         table_cache: &TableCache<S>,
-    ) -> Result<(Option<Slice>, SeekStats)> {
+    ) -> Result<(Option<Vec<u8>>, SeekStats)> {
         let ikey = key.internal_key();
         let ukey = key.user_key();
         let ucmp = self.icmp.user_comparator.as_ref();
@@ -185,7 +185,9 @@ impl Version {
                                     == CmpOrdering::Equal
                                 {
                                     match parsed_key.value_type {
-                                        ValueType::Value => return Ok((Some(value), seek_stats)),
+                                        ValueType::Value => {
+                                            return Ok((Some(value.into_vec()), seek_stats))
+                                        }
                                         ValueType::Deletion => return Ok((None, seek_stats)),
                                         _ => {}
                                     }


### PR DESCRIPTION
- Remove `Slice` in `DB::get` interface
- Remove `Slice` in `DBIterator`

Signed-off-by: Fullstop000 <fullstop1005@gmail.com>