### PR TITLE
*: make comparator generic

### DIFF
--- a/examples/simple_read_write.rs
+++ b/examples/simple_read_write.rs
@@ -12,36 +12,18 @@
 // limitations under the License.
 
 use wickdb::file::FileStorage;
-use wickdb::Options;
-use wickdb::ReadOptions;
-use wickdb::WickDB;
-use wickdb::WriteOptions;
-use wickdb::DB;
+use wickdb::{BytewiseComparator, Options, ReadOptions, WickDB, WriteOptions, DB};
 
 fn main() {
-    let options = Options::default();
+    let options = Options::<BytewiseComparator>::default();
     let storage = FileStorage::default();
-    let db = WickDB::open_db(options, "./test_db", storage).expect("could not open db");
-    db.put(
-        WriteOptions::default(),
-        "key1".as_bytes(),
-        "value1".as_bytes(),
-    )
-    .expect("could not success putting");
-    db.put(
-        WriteOptions::default(),
-        "key2".as_bytes(),
-        "value2".as_bytes(),
-    )
-    .expect("could not success putting");
-    let val1 = db
-        .get(ReadOptions::default(), "key1".as_bytes())
-        .expect("could not get key1");
-    let val2 = db
-        .get(ReadOptions::default(), "key2".as_bytes())
-        .expect("could not get key2");
+    let db = WickDB::open_db(options, "./test_db", storage).unwrap();
+    db.put(WriteOptions::default(), b"key1", b"value1").unwrap();
+    db.put(WriteOptions::default(), b"key2", b"value2").unwrap();
+    let val1 = db.get(ReadOptions::default(), b"key1").unwrap();
+    let val2 = db.get(ReadOptions::default(), b"key2").unwrap();
     assert!(val1.is_some());
     assert!(val2.is_some());
-    assert_eq!(String::from_utf8(val1.unwrap()).unwrap(), "value1");
-    assert_eq!(String::from_utf8(val2.unwrap()).unwrap(), "value2");
+    assert_eq!(val1.unwrap(), b"value1");
+    assert_eq!(val2.unwrap(), b"value2");
 }

--- a/src/iterator.rs
+++ b/src/iterator.rs
@@ -281,8 +281,9 @@ impl<T: KMergeCore> KMergeIter<T> {
 
 /// An trait defines the operation in k merge sort
 pub trait KMergeCore {
+    type Cmp: Comparator;
     /// Returns current comparator
-    fn cmp(&self) -> &dyn Comparator;
+    fn cmp(&self) -> &Self::Cmp;
 
     /// The inner child iterators size
     fn iters_len(&self) -> usize;
@@ -335,7 +336,7 @@ pub trait KMergeCore {
     /// Iterate each child iterator except the ith iterator and call `f`
     fn for_not_ith<F>(&mut self, i: usize, f: F)
     where
-        F: FnMut(&mut dyn Iterator, &dyn Comparator);
+        F: FnMut(&mut dyn Iterator, &Self::Cmp);
 
     /// Returns `Err` if inner children has errors.
     fn take_err(&mut self) -> Result<()>;
@@ -431,7 +432,8 @@ mod tests {
     }
 
     impl<I: Iterator, C: Comparator> KMergeCore for SimpleKMerger<I, C> {
-        fn cmp(&self) -> &dyn Comparator {
+        type Cmp = C;
+        fn cmp(&self) -> &Self::Cmp {
             &self.cmp
         }
 
@@ -480,7 +482,7 @@ mod tests {
 
         fn for_not_ith<F>(&mut self, n: usize, mut f: F)
         where
-            F: FnMut(&mut dyn Iterator, &dyn Comparator),
+            F: FnMut(&mut dyn Iterator, &Self::Cmp),
         {
             for (i, child) in self.children.iter_mut().enumerate() {
                 if i != n {

--- a/src/mem/skiplist.rs
+++ b/src/mem/skiplist.rs
@@ -683,6 +683,7 @@ mod tests {
         }
     }
 
+    #[derive(Clone, Copy, Default)]
     struct U64Comparator {}
     impl Comparator for U64Comparator {
         fn compare(&self, a: &[u8], b: &[u8]) -> CmpOrdering {

--- a/src/util/comparator.rs
+++ b/src/util/comparator.rs
@@ -21,7 +21,7 @@ use std::cmp::{min, Ordering};
 /// used as keys in an sstable or a database.  A Comparator implementation
 /// must be thread-safe since we may invoke its methods concurrently
 /// from multiple threads.
-pub trait Comparator: Send + Sync {
+pub trait Comparator: Send + Sync + Clone + Default {
     /// Three-way comparison. Returns value:
     ///   `Ordering::Less`    iff `a` < `b`
     ///   `Ordering::Equal`   iff `a` = `b`


### PR DESCRIPTION
This PR does things below :
- `Comparator` now must satisfy `Send + Sync + Clone + Default`
- Almost refactor all the place using `Arc<dyn Comparator>` by using `C: Comparator`

Signed-off-by: Fullstop000 <fullstop1005@gmail.com>