### PR TITLE
*: use inline skiplist as memtable

### DIFF
--- a/benches/mem/arena.rs
+++ b/benches/mem/arena.rs
@@ -12,7 +12,7 @@ fn bench_block_arena_allocate(c: &mut Criterion) {
             |b: &mut Bencher, size| {
                 b.iter_batched(
                     || BlockArena::default(),
-                    |arena| arena.allocate::<u8>(*size, 8),
+                    |arena| unsafe { arena.allocate::<u8>(*size, 8) },
                     BatchSize::PerIteration,
                 );
             },
@@ -28,8 +28,8 @@ fn bench_offset_arena_allocate(c: &mut Criterion) {
             size,
             |b: &mut Bencher, size| {
                 b.iter_batched(
-                    || ArenaV2::with_capacity(1 << 10),
-                    |arena| arena.allocate::<u8>(*size, 8),
+                    || OffsetArena::with_capacity(1 << 10),
+                    |arena| unsafe { arena.allocate::<u8>(*size, 8) },
                     BatchSize::PerIteration,
                 );
             },

--- a/src/batch.rs
+++ b/src/batch.rs
@@ -208,7 +208,10 @@ mod tests {
     use crate::util::comparator::BytewiseComparator;
 
     fn print_contents(batch: &WriteBatch) -> String {
-        let mem = MemTable::new(InternalKeyComparator::new(BytewiseComparator::default()));
+        let mem = MemTable::new(
+            1 << 32,
+            InternalKeyComparator::new(BytewiseComparator::default()),
+        );
         let result = batch.insert_into(&mem);
         let mut iter = mem.iter();
         iter.seek_to_first();

--- a/src/mem/mod.rs
+++ b/src/mem/mod.rs
@@ -99,6 +99,11 @@ impl<C: Comparator> MemTable<C> {
         self.table.len()
     }
 
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.table.len() == 0
+    }
+
     /// Add an entry into memtable that maps key to value at the
     /// specified sequence number and with the specified type.
     /// Typically value will be empty if the type is `Deletion`.

--- a/src/mem/skiplist.rs
+++ b/src/mem/skiplist.rs
@@ -49,7 +49,7 @@ impl Node {
         let pointers_size = height * mem::size_of::<AtomicPtr<Self>>();
         let size = mem::size_of::<Self>() + pointers_size;
         let align = mem::align_of::<Self>();
-        let p = arena.allocate(size, align) as *const Self as *mut Self;
+        let p = unsafe { arena.allocate(size, align) } as *const Self as *mut Self;
         unsafe {
             let node = &mut *p;
             ptr::write(&mut node.key, key);

--- a/src/sstable/mod.rs
+++ b/src/sstable/mod.rs
@@ -728,7 +728,7 @@ mod tests {
         fn new(is_reversed: bool) -> Self {
             let icmp = InternalKeyComparator::new(TestComparator::new(is_reversed));
             Self {
-                inner: MemTable::new(icmp),
+                inner: MemTable::new(1 << 32, icmp),
             }
         }
 


### PR DESCRIPTION
This PR does things below:
- Use `InlineSkiplist` as default memtable
- Add a new field `size` to track the memory size used instead of using `Arena` length 

Signed-off-by: Fullstop000 <fullstop1005@gmail.com>