### PR TITLE
crc: use crc32fast instead of crc32c

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -107,6 +107,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
 
 [[package]]
+name = "cfg-if"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
 name = "chrono"
 version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -135,10 +141,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
 
 [[package]]
-name = "crc32c"
-version = "0.4.0"
+name = "crc32fast"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77ba37ef26c12988c1cee882d522d65e1d5d2ad8c3864665b88ee92767ed84c5"
+checksum = "81156fece84ab6a9f2afdb109ce3ae577e42b1228441eded99bd77f627953b1a"
+dependencies = [
+ "cfg-if 1.0.0",
+]
 
 [[package]]
 name = "criterion"
@@ -210,7 +219,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5064ebdbf05ce3cb95e45c8b086f72263f4166b29b97f6baff7ef7fe047b55ac"
 dependencies = [
  "autocfg 0.1.7",
- "cfg-if",
+ "cfg-if 0.1.10",
  "crossbeam-utils 0.7.0",
  "lazy_static",
  "memoffset",
@@ -223,7 +232,7 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c695eeca1e7173472a32221542ae469b3e9aac3a4fc81f7696bcad82029493db"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
  "crossbeam-utils 0.7.0",
 ]
 
@@ -233,7 +242,7 @@ version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04973fa96e96579258a5091af6003abde64af786b860f18622b82e026cca60e6"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
  "lazy_static",
 ]
 
@@ -244,7 +253,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce446db02cdc3165b94ae73111e570793400d0794e46125cc4056c81cbb039f4"
 dependencies = [
  "autocfg 0.1.7",
- "cfg-if",
+ "cfg-if 0.1.10",
  "lazy_static",
 ]
 
@@ -276,7 +285,7 @@ version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13aea89a5c93364a98e9b37b2fa237effbb694d5cfe01c5b70941f7eb087d5e3"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
  "dirs-sys",
 ]
 
@@ -286,7 +295,7 @@ version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "afa0b23de8fd801745c471deffa6e12d248f962c9fd4b4c33787b055599bde7b"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
  "libc",
  "redox_users",
  "winapi",
@@ -323,7 +332,7 @@ version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7abc8dd8451921606d809ba32e95b6111925cd2906060d2dcc29c070220503eb"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
  "libc",
  "wasi",
 ]
@@ -370,7 +379,7 @@ version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "14b6052be84e6b71ab17edffc2eeabf5c2c3ae1fdb464aae35ac50c67a44e1f7"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
 ]
 
 [[package]]
@@ -793,7 +802,7 @@ name = "wickdb"
 version = "0.1.0"
 dependencies = [
  "bytes",
- "crc32c",
+ "crc32fast",
  "criterion",
  "crossbeam-channel 0.4.0",
  "crossbeam-utils 0.7.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ version = "0.1.0"
 
 [dependencies]
 bytes = "0.5.6"
-crc32c = "0.4.0"
+crc32fast = "1.2.1"
 crossbeam-channel = "0.4.0"
 crossbeam-utils = "0.7.0"
 fs2 = "0.4.3"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,7 +14,7 @@
 #![allow(clippy::rc_buffer)]
 #[macro_use]
 extern crate log;
-extern crate crc32c;
+extern crate crc32fast;
 extern crate crossbeam_channel;
 extern crate crossbeam_utils;
 extern crate slog;

--- a/src/record/mod.rs
+++ b/src/record/mod.rs
@@ -63,7 +63,7 @@ mod tests {
     use crate::record::{BLOCK_SIZE, HEADER_SIZE};
     use crate::storage::File;
     use crate::util::coding::encode_fixed_32;
-    use crate::util::crc32::{mask, hash};
+    use crate::util::crc32::{hash, mask};
     use crate::{Error, Result};
     use rand::Rng;
     use std::cell::RefCell;

--- a/src/record/mod.rs
+++ b/src/record/mod.rs
@@ -63,7 +63,7 @@ mod tests {
     use crate::record::{BLOCK_SIZE, HEADER_SIZE};
     use crate::storage::File;
     use crate::util::coding::encode_fixed_32;
-    use crate::util::crc32::{mask, value};
+    use crate::util::crc32::{mask, hash};
     use crate::{Error, Result};
     use rand::Rng;
     use std::cell::RefCell;
@@ -293,7 +293,7 @@ mod tests {
             let mut borrowed = self.source.borrow_mut();
             let contents = borrowed.as_mut_slice();
             // 6 = actual crc (4) + data length (2)
-            let mut crc = value(&contents[header_offset + 6..header_offset + 6 + len + 1]);
+            let mut crc = hash(&contents[header_offset + 6..header_offset + 6 + len + 1]);
             crc = mask(crc);
             encode_fixed_32(&mut contents[header_offset..header_offset + 4], crc)
         }

--- a/src/record/reader.rs
+++ b/src/record/reader.rs
@@ -19,7 +19,7 @@ use crate::record::reader::ReaderError::{BadRecord, EOF};
 use crate::record::{RecordType, BLOCK_SIZE, HEADER_SIZE};
 use crate::storage::File;
 use crate::util::coding::decode_fixed_32;
-use crate::util::crc32::{unmask, value};
+use crate::util::crc32::{unmask, hash};
 use std::io::SeekFrom;
 
 #[derive(Debug)]
@@ -294,7 +294,7 @@ impl<F: File> Reader<F> {
             if self.checksum {
                 let expected = unmask(decode_fixed_32(header));
                 // HEADER_SIZE - 1 to included the record type
-                let actual = value(&self.buf[HEADER_SIZE - 1..record_length]);
+                let actual = hash(&self.buf[HEADER_SIZE - 1..record_length]);
                 if expected != actual {
                     let drop_size = self.buf_length;
                     self.clear_buf();

--- a/src/record/reader.rs
+++ b/src/record/reader.rs
@@ -19,7 +19,7 @@ use crate::record::reader::ReaderError::{BadRecord, EOF};
 use crate::record::{RecordType, BLOCK_SIZE, HEADER_SIZE};
 use crate::storage::File;
 use crate::util::coding::decode_fixed_32;
-use crate::util::crc32::{unmask, hash};
+use crate::util::crc32::{hash, unmask};
 use std::io::SeekFrom;
 
 #[derive(Debug)]

--- a/src/record/writer.rs
+++ b/src/record/writer.rs
@@ -38,7 +38,7 @@ impl<F: File> Writer<F> {
         let mut cache = [0; RecordType::Last as usize + 1];
         for h in 1..=n {
             let v: [u8; 1] = [RecordType::from(h) as u8];
-            cache[h as usize] = crc32::value(&v);
+            cache[h as usize] = crc32::hash(&v);
         }
         Self {
             dest,

--- a/src/sstable/table.rs
+++ b/src/sstable/table.rs
@@ -25,7 +25,7 @@ use crate::sstable::{BlockHandle, Footer, BLOCK_TRAILER_SIZE, FOOTER_ENCODED_LEN
 use crate::storage::File;
 use crate::util::coding::{decode_fixed_32, put_fixed_32, put_fixed_64};
 use crate::util::comparator::Comparator;
-use crate::util::crc32::{extend, mask, unmask, value};
+use crate::util::crc32::{extend, mask, unmask, hash};
 use crate::{Error, Result};
 use snap::raw::max_compress_len;
 use std::cmp::Ordering;
@@ -557,7 +557,7 @@ fn write_raw_block<F: File>(
     // TODO: use pre-allocated buf
     let mut trailer = vec![];
     trailer.push(compression as u8);
-    let crc = mask(extend(value(data), &[compression as u8]));
+    let crc = mask(extend(hash(data), &[compression as u8]));
     put_fixed_32(&mut trailer, crc);
     assert_eq!(trailer.len(), BLOCK_TRAILER_SIZE);
     file.write(trailer.as_slice())?;
@@ -576,7 +576,7 @@ fn read_block<F: File>(file: &F, handle: &BlockHandle, verify_checksum: bool) ->
     if verify_checksum {
         let crc = unmask(decode_fixed_32(&buffer[n + 1..]));
         // Compression type is included in CRC checksum
-        let actual = value(&buffer[..=n]);
+        let actual = hash(&buffer[..=n]);
         if crc != actual {
             return Err(Error::Corruption("block checksum mismatch".to_owned()));
         }

--- a/src/sstable/table.rs
+++ b/src/sstable/table.rs
@@ -25,7 +25,7 @@ use crate::sstable::{BlockHandle, Footer, BLOCK_TRAILER_SIZE, FOOTER_ENCODED_LEN
 use crate::storage::File;
 use crate::util::coding::{decode_fixed_32, put_fixed_32, put_fixed_64};
 use crate::util::comparator::Comparator;
-use crate::util::crc32::{extend, mask, unmask, hash};
+use crate::util::crc32::{extend, hash, mask, unmask};
 use crate::{Error, Result};
 use snap::raw::max_compress_len;
 use std::cmp::Ordering;

--- a/src/util/crc32.rs
+++ b/src/util/crc32.rs
@@ -81,10 +81,7 @@ mod tests {
 
     #[test]
     pub fn test_extend() {
-        assert_eq!(
-            hash(b"hello world"),
-            extend(hash(b"hello "), b"world")
-        );
+        assert_eq!(hash(b"hello world"), extend(hash(b"hello "), b"world"));
     }
 
     #[test]

--- a/src/util/crc32.rs
+++ b/src/util/crc32.rs
@@ -11,17 +11,21 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crc32c::{crc32c, crc32c_append};
+use crc32fast::Hasher;
 
 const MASK_DELTA: u32 = 0xa282ead8;
 
 /// Returns a `u32` crc checksum for give data
-pub fn value(data: &[u8]) -> u32 {
-    crc32c(data)
+pub fn hash(data: &[u8]) -> u32 {
+    let mut h = Hasher::new();
+    h.update(data);
+    h.finalize()
 }
 
 pub fn extend(crc: u32, data: &[u8]) -> u32 {
-    crc32c_append(crc, data)
+    let mut h = Hasher::new_with_initial(crc);
+    h.update(data);
+    h.finalize()
 }
 
 /// Return a masked representation of crc.
@@ -46,20 +50,20 @@ mod tests {
     #[test]
     pub fn test_standard_crc32_results() {
         let buf: Vec<u8> = vec![0; 32];
-        assert_eq!(value(&buf), 0x8a9136aa);
+        assert_eq!(hash(&buf), 0x190a55ad);
 
         let mut buf: Vec<u8> = vec![0xff; 32];
-        assert_eq!(value(&buf), 0x62a8ab43);
+        assert_eq!(hash(&buf), 0xff6cab0b);
 
         for i in 0..32 {
             buf[i] = i as u8;
         }
-        assert_eq!(value(&buf), 0x46dd794e);
+        assert_eq!(hash(&buf), 0x91267e8a);
 
         for i in 0..32 {
             buf[i] = (31 - i) as u8;
         }
-        assert_eq!(value(&buf), 0x113fdb5c);
+        assert_eq!(hash(&buf), 0x9ab0ef72);
 
         let data = [
             0x01, 0xc0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
@@ -67,25 +71,25 @@ mod tests {
             0x00, 0x00, 0x00, 0x18, 0x28, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0x00,
             0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
         ];
-        assert_eq!(value(&data), 0xd9963a56);
+        assert_eq!(hash(&data), 0x51e17412);
     }
 
     #[test]
     pub fn test_values() {
-        assert_ne!(value("a".as_bytes()), value("foo".as_bytes()));
+        assert_ne!(hash(b"a"), hash(b"foo"));
     }
 
     #[test]
     pub fn test_extend() {
         assert_eq!(
-            value("hello world".as_bytes()),
-            extend(value("hello ".as_bytes()), "world".as_bytes())
+            hash(b"hello world"),
+            extend(hash(b"hello "), b"world")
         );
     }
 
     #[test]
     pub fn test_mask_unmask() {
-        let crc = value("foo".as_bytes());
+        let crc = hash(b"foo");
         assert_ne!(mask(crc), crc);
         assert_ne!(mask(mask(crc)), crc);
         assert_eq!(unmask(mask(crc)), crc);


### PR DESCRIPTION
`crc32fast` supports SIMD in aarch64

Signed-off-by: Fullstop000 <fullstop1005@gmail.com>