### PR TITLE
[cache] fix memory leak when erase key

### DIFF
--- a/src/cache/lru.rs
+++ b/src/cache/lru.rs
@@ -224,6 +224,11 @@ where
                     cb(key, &(*n.value.as_ptr()));
                 }
             }
+            // should manually drop kv [MaybeUninit]
+            unsafe {
+                ptr::drop_in_place(n.key.as_mut_ptr());
+                ptr::drop_in_place(n.value.as_mut_ptr());
+            }
         }
     }
 


### PR DESCRIPTION
Just reading the code, I think here is memory leak. @Fullstop000  😆 If i am wrong plz tell me. 
By the way, this is the *best* implementation i even seen in rust 👍 